### PR TITLE
Update Stockholm sprint README and add D12.2 draft structure

### DIFF
--- a/stockholm_sprint_2026/D12.2/README.md
+++ b/stockholm_sprint_2026/D12.2/README.md
@@ -1,0 +1,368 @@
+# Deliverable D12.2 - Large Language Models for Official Statistics
+
+## Overview
+
+This document provides the draft structure and initial content for **Deliverable D12.2** of **Work Package 12 (WP12)** within the AIML4OS project. D12.2 builds on the work done for D12.1 (Lisbon hackathon, June 2025) and incorporates the outputs, reflections, and evaluations from the Stockholm sprint (June 2026).
+
+The deliverable documents practical LLM-based prototypes for official statistics, including use-case descriptions, architectural considerations, evaluation results, and guidance for implementation and reuse by National Statistical Institutes (NSIs).
+
+## Structure
+
+The deliverable follows the structure established by D12.1, extended with additional sections on scope, limitations, quality assessment of GenAI approaches, and future considerations.
+
+---
+
+## 1. Introduction
+
+### 1.1 Background
+
+WP12 explores how large language models (LLMs) and generative AI can be used in the context of official statistics. The work includes both practical prototype development and reflection on how such systems can be implemented in a way that supports reuse, data protection, transparency, evaluation and operational relevance.
+
+### 1.2 Objectives of D12.2
+
+- Document the prototypes developed and extended during the Stockholm sprint (June 2026)
+- Provide evaluation results using a shared evaluation framework
+- Describe architectural choices and their implications
+- Capture lessons learned and guidance for NSIs considering LLM-based approaches
+- Identify scope, limitations, and future directions
+
+### 1.3 Relationship to D12.1
+
+D12.1 was based on the Lisbon hackathon (June 2025) and included three prototypes:
+1. Dissemination summary (PDF summarisation and keyword extraction)
+2. From PDF to figures (structured data extraction from PDFs)
+3. Web Corner (web scraping and LLM content classification)
+
+D12.2 continues and extends this work, with a focus on:
+- **News Corner** (statistical media consistency checking) — new use case
+- **Web Corner** (agentic web scraping) — extended from D12.1
+- **Metadata management using AI** (graph-based metadata interaction) — new use case
+
+---
+
+## 2. Evaluation Framework
+
+To support sustainability and maintainability of AI systems developed within the project, each use case and prototype is evaluated along the following dimensions:
+
+| Criterion | Description |
+|---|---|
+| Efficiency gain | How much effort does the prototype save compared to manual or existing approaches? |
+| Reusability | Can other NSIs download, configure, and run the prototype with minimal changes? |
+| Data accessibility | Are the required input data and resources openly available or easily obtainable? |
+| On-prem compatibility | Can the prototype run in an on-premises environment without external API dependencies? |
+| Low-hanging fruit for NSIs | How easy is it for an NSI to adopt the prototype with existing infrastructure? |
+| Evaluation robustness | How well can the quality of outputs be assessed and benchmarked? |
+| Feasibility | Is the prototype technically achievable within realistic resource constraints? |
+| Lifespan | How long is the prototype expected to remain useful given evolving technologies and data? |
+| Cost effectiveness | What are the operational costs (API calls, compute, maintenance) relative to the value? |
+
+---
+
+## 3. Architecture Perspective
+
+### 3.1 General Approach
+
+The prototypes share a common architectural approach:
+- Use of LLMs only where semantic interpretation is required
+- Deterministic logic for ingestion, parsing, deduplication, scheduling, and scoring
+- Modular design allowing individual components to be replaced
+- Cost-aware design minimising unnecessary API calls
+
+### 3.2 Shared Infrastructure
+
+- **SSPCloud (Onyxia)**: shared development and hosting environment provided by WP3
+- **LLM endpoints**: both SSPCloud-hosted open-source models (e.g., GEMMA4-26B-MOE) and commercial APIs
+- **Tool-calling**: used by agentic prototypes for structured interaction with external systems
+
+### 3.3 Architecture Diagrams
+
+<!-- TODO: Add architecture diagrams for each prototype -->
+_Placeholder: architecture diagrams to be added._
+
+---
+
+## 4. Use Cases and Prototypes
+
+### 4.1 News Corner - Statistical Media Consistency
+
+#### 4.1.1 Description
+
+A prototype system for comparing newspaper articles with official National Statistical Institute (NSI) releases. It uses an LLM to interpret and compare web content, identifying when media articles refer to specific statistical releases and how accurately those releases are reported.
+
+The system retrieves RSS feeds from newspapers and NSIs, stores metadata and content locally, generates candidate article-release pairs, uses an LLM for semantic comparison, and produces alignment scores.
+
+#### 4.1.2 Input and Output
+
+- **Input**: RSS feeds from news websites and official releases from NSIs
+- **Output**: Alignment indication measuring how closely each news article matches the corresponding official release, across five dimensions (topic match, figures accuracy, reference period, source attribution, framing consistency)
+
+#### 4.1.3 Architecture
+
+The prototype is implemented in Python, using standard libraries wherever possible. The architecture is modular with the following components:
+
+1. Configuration Module
+2. Scheduling Module
+3. Feed Ingestion Module
+4. Storage Module (SQLite + raw files)
+5. Deduplication Module
+6. Candidate Matching Module
+7. LLM Analysis Module
+8. Alignment Scoring Module
+9. Benchmarking Module
+10. Reporting Module
+11. Graphical User Interface Module
+
+See [Draft-architecture.md](../News_Corner/Draft-architecture.md) for the full architecture specification.
+
+#### 4.1.4 Evaluation Results
+
+The system was tested using GEMMA4-26B-MOE hosted on SSPCloud Onyxia and supplementary tests with ChatGPT 5.5.
+
+| Test | Languages | Expected | Result | Outcome |
+|---|---|---|---|---|
+| CBS vs NL Times (consistent) | English | Consistent | Consistent | Passed |
+| CBS vs NL Times (different topic) | English | Inconsistent | Inconsistent | Passed |
+| CBS vs NL Times (wrong figures/period) | English | Inconsistent | Inconsistent | Passed |
+| CBS (Dutch) vs NL Times (English) | Dutch/English | Consistent | Consistent | Passed |
+| SURS vs RTVSLO (year mismatch) | Slovenian | Inconsistent | Consistent | Failed |
+| Same case with ChatGPT 5.5 | Slovenian | Inconsistent | Inconsistent | Passed |
+
+See [Report.md](../News_Corner/Report.md) for detailed test results.
+
+#### 4.1.5 Evaluation Summary
+
+| Criterion | Assessment |
+|---|---|
+| Efficiency gain | High, compared to manual work |
+| Reusability | High, just download, configure, and run |
+| Data accessibility | Medium/Low, due to paywalls on news articles |
+| On-prem compatibility | High |
+| Low-hanging fruit for NSIs | Medium/Low |
+| Evaluation robustness | High, using a benchmark dataset |
+| Feasibility | High |
+| Lifespan | Medium, because of fast changes in media |
+| Cost effectiveness | High, compared to manual work |
+
+---
+
+### 4.2 Web Corner - Agentic Web Scraping
+
+#### 4.2.1 Description
+
+A proof of concept for using LLMs as agentic web scrapers. The system takes a natural language prompt including a starting URL and a specific goal, and returns structured information along with a step-by-step reasoning trace.
+
+#### 4.2.2 Input and Output
+
+- **Input**: A natural language prompt including a starting URL and a specific goal (e.g., "Find all job listings related to information security on the SCB website. Start at www.scb.se")
+- **Output**: A structured response containing the requested information, the relevant URLs found, and a step-by-step reasoning trace
+
+#### 4.2.3 Architecture
+
+The system uses an LLM with tool-calling capabilities. The tools are kept "atomic" (performing only one small task) for higher reliability:
+- `fetch_page_urls`: Retrieve hyperlinks from a URL
+- `fetch_page_content`: Fetch page content from a URL
+- `interact_with_web`: Playwright-based interaction for dynamic content
+
+Integration with Playwright has been initiated to handle JavaScript-heavy websites.
+
+#### 4.2.4 Evaluation Results
+
+The proof of concept was evaluated across several diverse use cases:
+- **Comparative Analysis**: Finding specific articles on a topic across multiple sources
+- **Job Discovery**: Matching job offerings to specific professional descriptions
+- **E-commerce Extraction**: Fetching product catalogs and real-time pricing
+- **NSI Data Comparison**: Fetching and comparing inflation numbers from SCB and CBS
+
+#### 4.2.5 Evaluation Summary
+
+| Criterion | Assessment |
+|---|---|
+| Efficiency gain | High in generic applicability; Low in raw runtime speed |
+| Reusability | High |
+| On-prem compatibility | Medium/High (requires local LLM with tool-calling) |
+| Feasibility | Medium |
+| Lifespan | Medium/High |
+| Performance vs. chatbots | Comparable; often superior due to specialized system prompting |
+
+#### 4.2.6 Key Takeaways
+
+- **System Prompting** is the most critical component for tuning behaviour from a generic LLM into a specialised scraping agent
+- **Reasoning Trade-offs**: Enabling chain-of-thought reasoning significantly improves output quality but increases inference latency
+- **Tool Design**: Keeping tools atomic ensures higher reliability during the LLM's tool-calling phase
+
+---
+
+### 4.3 Metadata Management using AI
+
+#### 4.3.1 Description
+
+A prototype exploring the use of an AI-powered knowledge graph as a foundation for metadata management in statistical offices. Users interact with statistical metadata (variables, concepts, data structures, code lists, etc.) through natural language, while the underlying graph captures and enforces the relationships defined by standards like GSIM and SDMX.
+
+#### 4.3.2 Input and Output
+
+- **Input**: Natural language queries and/or uploaded documents describing statistical metadata
+- **Output**: A navigable, visual knowledge graph and conversational answers grounded in the graph's content
+
+#### 4.3.3 Architecture
+
+The software is a profile-based knowledge graph platform with:
+- **Frontend**: React (React Flow visualisation)
+- **Backend**: FastAPI + NetworkX
+- **AI layer**: Claude or any OpenAI-compatible LLM with tool calling
+- **Domain model**: 8 node types (Actor, StatisticalProgramme, DataSet, DataStructure, InstanceVariable, Concept, UnitType, CodeList) and 9 relationship types modelled after GSIM
+
+Configuration is fully driven by a profile schema — no code changes are needed to adapt the domain model.
+
+#### 4.3.4 Evaluation Criteria
+
+- **Discoverability**: Can users find related metadata faster than in existing registries?
+- **Interoperability**: Does the graph model align with GSIM/SDMX well enough to support real metadata exchange workflows?
+- **Collaboration**: Can multiple statistical offices contribute to and benefit from a shared metadata landscape?
+- **Flexibility**: How easily can the schema be adapted to other statistical domains?
+
+#### 4.3.5 Evaluation Summary
+
+| Criterion | Assessment |
+|---|---|
+| Efficiency gain | High in discoverability and cross-office collaboration |
+| Reusability | High — profile system supports any metadata domain without code changes |
+| Data accessibility | <!-- TODO: to be assessed --> |
+| On-prem compatibility | Medium/High — requires an LLM endpoint with tool-calling support |
+| Low-hanging fruit for NSIs | <!-- TODO: to be assessed --> |
+| Evaluation robustness | <!-- TODO: to be assessed --> |
+| Feasibility | Medium — seed data demonstrates the concept, real-world coverage requires curation |
+| Lifespan | Medium/High — standards-aligned schema (GSIM/SDMX) and LLM-agnostic design |
+| Cost effectiveness | <!-- TODO: to be assessed --> |
+
+#### 4.3.6 Current Status
+
+<!-- TODO: Update with final sprint outputs -->
+- Graph seeded with ESS actors and their relationships
+- Statistical programmes linked to datasets and data structures
+- Variables, concepts, unit types, and code lists modelled and connected
+- Natural language queries resolve against the metadata graph
+- AI extracts entities and relationships from uploaded documents
+- Duplicate detection flags overlapping definitions across offices
+
+---
+
+## 5. Scope and Limitations
+
+### 5.1 General Limitations
+
+- All prototypes are **proof-of-concept implementations** developed during time-limited sprints and are not production-ready.
+- Results are **model-dependent**: switching LLM provider, version, or configuration may produce different outcomes.
+- **Evaluation datasets are small**: broader, systematic evaluation is needed before generalising findings.
+- **Reproducibility** is limited by the non-deterministic nature of LLM outputs; the same prompt may yield different results across runs.
+
+### 5.2 Data and Access Limitations
+
+- Some use cases depend on **paywalled or restricted content** (e.g., newspaper articles behind paywalls).
+- **Language coverage** is uneven: English performs best, while other European languages show variable quality.
+- Access to **internal NSI metadata** and production systems was not available during the sprint.
+
+### 5.3 Technical Limitations
+
+- **On-premises deployment** of open-source models with tool-calling support remains challenging for some NSIs.
+- **Latency and cost** of LLM API calls may limit operational-scale deployment.
+- **Dynamic web content** (JavaScript-heavy sites) is not yet reliably handled by the web scraping prototype.
+- The metadata prototype requires **curation effort** to populate the knowledge graph with real-world data.
+
+### 5.4 Methodological Limitations
+
+- The **evaluation framework** relies partly on subjective assessments by sprint participants.
+- **Human benchmark data** is limited to a small number of test cases for the News Corner prototype.
+- No **longitudinal evaluation** has been performed to assess how outputs change as models are updated.
+
+---
+
+## 6. Quality of GenAI-based Approaches
+
+This section captures observations and reflections on the quality of results produced by generative AI approaches during the sprint.
+
+### 6.1 Strengths Observed
+
+- LLMs performed well on **structured English-language tasks** such as comparing statistical releases with news articles and extracting information from web pages.
+- **Multilingual comparison** (e.g., Dutch source vs. English article) worked correctly in tested cases.
+- **Agentic tool-calling** enabled flexible, multi-step workflows that adapted to different website structures without manual code changes.
+- **Prompt engineering** had a significant and positive impact on result quality when done carefully.
+
+### 6.2 Weaknesses and Failure Modes
+
+- Models can **miss subtle mismatches**, such as reference-period year differences in non-English text (Slovenian test case).
+- **Chain-of-thought reasoning** improves quality but increases latency and cost, creating a practical trade-off.
+- **Open-source models** (e.g., GEMMA4-26B-MOE on SSPCloud) showed promising but uneven quality compared to commercial alternatives (ChatGPT 5.5).
+- Model outputs are **non-deterministic**: the same input may produce different quality outputs across runs.
+
+### 6.3 Practical Recommendations
+
+- Use **structured prompts** with explicit step-by-step instructions (e.g., extract reference period before making a judgement).
+- Implement **benchmark datasets** to track quality over time and across model changes.
+- Consider **model comparison** as part of the evaluation workflow (e.g., running difficult cases through multiple models).
+- Keep **tool interfaces atomic** and well-defined to reduce failure points in agentic setups.
+
+---
+
+## 7. Future Considerations
+
+### 7.1 Prototype Development
+
+- Extend News Corner with automated RSS feed monitoring and dashboard reporting.
+- Complete Playwright integration for Web Corner to handle dynamic web content reliably.
+- Expand the metadata knowledge graph with real-world ESS data and test federation across organisations.
+
+### 7.2 Evaluation and Benchmarking
+
+- Create shared benchmark datasets for each use case to enable systematic model comparison.
+- Develop human-in-the-loop evaluation workflows for ongoing quality assessment.
+- Compare LLM-based approaches with rule-based baselines and existing tools.
+
+### 7.3 Deployment and Reuse
+
+- Package prototypes for easy deployment by other NSIs (containerisation, configuration templates).
+- Test on-premises deployment with open-source models to support NSIs with data-protection constraints.
+- Document deployment guides and minimum infrastructure requirements.
+
+### 7.4 Integration
+
+- Explore integration with existing statistical production systems and metadata registries.
+- Investigate how prototype outputs can feed into quality assurance and dissemination workflows.
+- Consider alignment with GSBPM and other statistical process models.
+
+### 7.5 Research Directions
+
+- Investigate fine-tuning or domain adaptation of open-source models for statistical tasks.
+- Explore multi-agent architectures for complex statistical workflows.
+- Assess the impact of retrieval-augmented generation (RAG) on output quality for metadata and dissemination tasks.
+
+---
+
+## 8. Conclusions
+
+<!-- TODO: To be written after sprint outputs are finalised -->
+
+_Placeholder: conclusions to be drafted based on final sprint results and evaluations._
+
+---
+
+## Appendices
+
+### Appendix A: Sprint Agenda
+
+See [agenda.md](../agenda.md)
+
+### Appendix B: Background Material
+
+See [background.md](../background.md)
+
+### Appendix C: Use-case Planning
+
+See [use-case-planning.md](../use-case-planning.md)
+
+### Appendix D: News Corner Detailed Test Report
+
+See [News_Corner/Report.md](../News_Corner/Report.md)
+
+### Appendix E: News Corner Architecture
+
+See [News_Corner/Draft-architecture.md](../News_Corner/Draft-architecture.md)

--- a/stockholm_sprint_2026/README.md
+++ b/stockholm_sprint_2026/README.md
@@ -1,14 +1,14 @@
 # WP12 Sprint - Stockholm 2026
 
-This folder contains planning material and outputs from the WP12 sprint on Large Language Models to be held in **Stockholm, Sweden, 16-18 June 2026**.
+This folder contains planning material and outputs from the WP12 sprint on Large Language Models held in **Stockholm, Sweden, 16-18 June 2026**, with participation from project members representing several countries, and with technical support from France through WP3 (SSPCloud/Onyxia infrastructure).
 
-The sprint will take place at **Statistics Sweden (SCB)**:
+The sprint took place at **Statistics Sweden (SCB)**:
 
-**Solna strandväg 86**  
-**171 54 Solna**  
+**Solna strandväg 86**
+**171 54 Solna**
 **Stockholm, Sweden**
 
-## Purpose of the sprint
+## Purpose of the Sprint
 
 The sprint is organised as part of **Work Package 12 (WP12) - Use Case: Large Language Models** within the AIML4OS project.
 
@@ -18,17 +18,83 @@ The sprint builds on the experience from the WP12 hackathon held in Lisbon in Ju
 
 A key ambition for the Stockholm sprint is to make progress on both prototype development and the draft structure and initial content for the next WP12 deliverable, **D12.2**. Work during the sprint should therefore capture technical outputs as well as documentation, reflections and evaluation considerations needed for the deliverable.
 
-## Planned focus
+## Evaluation Framework
 
-The detailed focus areas will be agreed with participants during the sprint. The initial planning is expected to include:
+To support sustainability and maintainability of AI systems developed within the project, each use case and prototype is evaluated along the following dimensions:
 
-- WP12 status and objectives
-- Selection and refinement of use cases
-- Setup of shared collaboration spaces and development environments
-- Prototype development and testing
-- Documentation and reporting of sprint outputs
-- Drafting material for D12.2
-- Discussion of next steps for WP12 deliverables
+- **Efficiency gain**
+- **Reusability**
+- **Data accessibility**
+- **On-prem compatibility**
+- **Low-hanging fruit (for NSIs)**
+- **Evaluation robustness**
+- **Feasibility**
+- **Lifespan**
+- **Cost effectiveness**
+
+## Architecture Perspective
+
+An architecture perspective was introduced at the start of the hackathon and continued during the sprint to guide prototype development and encourage conscious choices around components such as:
+
+- AI models (LLMs)
+- APIs and tool-calling interfaces
+- Frameworks and orchestration
+- Hosting and on-prem considerations
+
+A generic reference model is used as a starting point and extended by each group.
+
+## Use Cases
+
+The sprint focused on the following use cases:
+
+### 1. News Corner - Statistical Media Consistency
+
+Monitoring how official statistics are reported in the media. The system collects RSS feeds from newspapers and NSIs, compares articles with official releases using an LLM, and produces alignment scores across five dimensions (topic match, figures accuracy, reference period, source attribution, framing consistency).
+
+See: [`News_Corner/`](News_Corner/)
+
+### 2. Web Corner - Agentic Web Scraping
+
+Using LLMs as agentic web scrapers that can navigate websites, extract structured information, and classify web content according to statistical concepts. The approach uses tool-calling and chain-of-thought reasoning to handle diverse websites without manual code changes.
+
+See: [`webcorner/`](webcorner/)
+
+### 3. Metadata Management using AI
+
+Exploring how AI can support the management, structuring and use of metadata in official statistics, using a graph-based structure to represent statistical programmes, datasets, variables, data structures, code lists and related metadata objects.
+
+See: [`metadata/`](metadata/)
+
+## Scope and Limitations
+
+- The prototypes developed during the sprint are **proof-of-concept implementations** and are not intended for production use.
+- The work relies on **experimental LLM APIs** (SSPCloud/Onyxia-hosted models and commercial APIs) that may change behaviour or availability over time.
+- Test datasets are **limited in size and diversity**; broader evaluation is needed before drawing general conclusions about model reliability across languages, topics, and statistical domains.
+- **Data accessibility** varies across use cases: some rely on publicly available RSS feeds or websites, while others depend on access to internal NSI data or metadata registries.
+- The sprint had a **fixed time frame** (three days), which limited the depth of evaluation and the number of use cases that could be explored.
+- **On-premises compatibility** depends on the availability of local LLM endpoints with tool-calling support; not all models or hosting setups meet this requirement.
+- Results are **model-dependent** and may differ across LLM providers, versions, and configurations.
+
+## Quality of GenAI-based Approaches
+
+The sprint provided practical experience with using generative AI for several statistical tasks. Key observations on output quality include:
+
+- LLMs performed **well on structured English-language tasks** such as comparing statistical releases with news articles and extracting information from web pages.
+- **Multilingual performance** was generally good but showed weaknesses in edge cases, such as detecting reference-period mismatches in Slovenian text.
+- **Prompt design** had a significant impact on result quality; carefully structured prompts with explicit instructions (e.g., requiring full reference-period extraction before judgement) produced notably better results.
+- The **reasoning trace** provided by agentic setups (chain-of-thought) improved output quality but increased inference latency and cost.
+- **Reproducibility** varied: the same prompt could yield different results across runs or model versions, highlighting the importance of evaluation benchmarks.
+- Open-source models hosted on SSPCloud (e.g., GEMMA4-26B-MOE) showed **promising but uneven quality** compared to commercial models, particularly for complex or multilingual tasks.
+
+## Future Considerations
+
+- **Benchmark development**: Create shared benchmark datasets for each use case so that model performance can be tracked over time and across LLM versions.
+- **On-prem deployment**: Further testing of open-source models in on-premises environments to support NSIs with strict data-protection requirements.
+- **Cross-NSI reuse**: Package prototypes so that other NSIs can deploy and configure them with minimal effort.
+- **Integration with existing workflows**: Explore how prototype outputs can feed into existing statistical production systems (dissemination, metadata registries, quality assurance).
+- **Evaluation methodology**: Develop more robust evaluation approaches, including human-in-the-loop validation and comparison with rule-based baselines.
+- **Scaling**: Assess performance and cost implications of running prototypes at operational scale (e.g., monitoring hundreds of RSS feeds or classifying thousands of web pages).
+- **D12.2 deliverable**: Use sprint outputs as core input for the next WP12 deliverable.
 
 ## Agenda
 
@@ -36,15 +102,48 @@ The draft agenda is available here:
 
 - [agenda.md](agenda.md)
 
-## Expected outputs
+## Folder Structure
 
-The expected outputs will be refined during the sprint, but may include:
+Each prototype folder contains:
 
-- updated or new LLM prototype material
-- documentation of selected use cases and implementation approaches
-- reflections on architectural and evaluation aspects
-- draft material for D12.2
-- material that can support future WP12 deliverables
+- A clear description of the **use case**
+- Evaluation summary based on the above criteria
+- A **mapping to architectural components** used
+- Code and/or scripts that can be used to understand and test the prototype, especially within the **SSPCloud (Onyxia)** environment
+
+```plaintext
+stockholm_sprint_2026/
+├── README.md                      # This file
+├── agenda.md                      # Sprint agenda
+├── background.md                  # Background on WP12 and AIML4OS
+├── use-case-planning.md           # Use-case planning notes
+├── remote-participation.md        # Remote participation info
+├── meeting_notes/                 # Meeting notes
+├── News_Corner/                   # News Corner prototype (media consistency)
+│   ├── README.md
+│   ├── Report.md
+│   ├── Draft-architecture.md
+│   └── News-Corner-app.pptx
+├── webcorner/                     # Web Corner prototype (agentic web scraping)
+│   ├── README.md
+│   ├── main.py
+│   ├── config/
+│   ├── tools/
+│   └── output*.md
+├── metadata/                      # Metadata management prototype
+│   └── README.md
+└── D12.2/                         # Draft structure for deliverable D12.2
+    └── README.md
+```
+
+## First Steps to Start
+
+The projects within this repository require an API key. To retrieve it, you'll need an SSP Cloud account. If it's not already done, create an account on the [SSP Cloud](https://datalab.sspcloud.fr/) platform. Then, to get your API key, go to [the AI chatbot hosted on the platform](https://llm.lab.sspcloud.fr) > settings > account > API KEYS
+
+Add your API key in an environment variable (LLM_API_KEY):
+```
+export LLM_API_KEY=your_api_key_you_just_retrieved
+```
 
 ## Note
 


### PR DESCRIPTION
## Summary

- **Updated `stockholm_sprint_2026/README.md`**: Combined and unified headlines from all three prototype READMEs (News Corner, Web Corner, Metadata) into a single coherent sprint README, aligned with the `wp12_hackathon` (D12.1) structure
- **Added missing sections**: Evaluation Framework, Architecture Perspective, Use Cases overview, Scope and Limitations, Quality of GenAI-based Approaches, Future Considerations, Folder Structure, First Steps to Start
- **Created `stockholm_sprint_2026/D12.2/README.md`**: Full draft deliverable structure mirroring D12.1, with 8 chapters covering introduction, evaluation framework, architecture, all three use cases (with gathered sprint material), scope/limitations, GenAI quality assessment, future considerations, and appendices. `<!-- TODO -->` placeholders mark where content is still pending.

## Test plan

- [ ] Review that all headlines from News Corner, Web Corner, and Metadata READMEs are represented in the sprint README
- [ ] Verify D12.2 structure covers all sections present in the hackathon (D12.1) README
- [ ] Check that evaluation tables and test results are correctly transcribed from source documents
- [ ] Confirm TODO placeholders are present where information was not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hvR1ce75NCALGf2ccRCgo

---
_Generated by [Claude Code](https://claude.ai/code/session_017hvR1ce75NCALGf2ccRCgo)_